### PR TITLE
不要なライブラリを削除

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,13 +7,10 @@ version '1.0-SNAPSHOT'
 
 repositories {
     mavenCentral()
-    maven { url "https://repo1.maven.org/maven2/org/seleniumhq/selenium/"}
 }
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
-    compile 'org.seleniumhq.selenium:selenium-java:3.11.0'
-    compile 'org.seleniumhq.selenium:htmlunit-driver:2.29.0'
     compile 'org.jsoup:jsoup:1.7.3'
 }
 


### PR DESCRIPTION
はじめまして

build.gradleを眺めていたところ、使用していないライブラリがあったので削除しました。
サイズの大きさに悩んでいたっぽそうだったので。
https://twitter.com/yt8492/status/1114127073457528832

<img width="500" alt="スクリーンショット 2019-04-06 9 46 02" src="https://user-images.githubusercontent.com/4579774/55662716-facede00-5850-11e9-9b9e-e03e942dd08b.png">

再度jarを作成すると1.7MBに減りました。
