### PR TITLE
Fix the shortage of urls due to the default limit.

### DIFF
--- a/src/main/kotlin/JsoupUtils.kt
+++ b/src/main/kotlin/JsoupUtils.kt
@@ -29,6 +29,6 @@ object JsoupUtils {
     @JvmStatic
     fun getConnection(url: String): Connection {
         Thread.sleep(1000)
-        return Jsoup.connect(url).timeout(100000)
+        return Jsoup.connect(url).timeout(100000).maxBodySize(0)
     }
 }


### PR DESCRIPTION
Jsoup added the limitation of maximum body's size on Json.Connection.
Default value is set to 1MB.

Unfortunately, DLSite produces about 2KB HTML for each item.
As a result, purchase history exceeds the this limit when he/she bought about 400 or more.

-------------------------------------------------------------------------------------------------------

購入履歴が大体400個を超えたあたりでJsoupのサイズ制限に引っかかるので無制限に変更しました。